### PR TITLE
Add arrays_with_sortkey format to tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The behavior of the cidr, regexp and pcre table depends on the ordering of the c
 The `_format` configuration options defines how the order is created. The following options are supported:
 
 * `pairs_sorted_by_key`: The key->value pairs are sorted by key. Key and value are separated by a blank.
+* `arrays_with_sortkey`: The key->value pairs are sorted by key. The key remains unused in output and instead `value[0]` and `value[1]` will be separated by a blank in output.
 
 Other formats are planed.
 

--- a/libraries/tables.rb
+++ b/libraries/tables.rb
@@ -145,12 +145,17 @@ module Postfix
     register self, %w(cidr regexp pcre)
 
     def generate_config_content()
-      unless params['format'] == 'pairs_sorted_by_key'
+      if params['format'] == 'pairs_sorted_by_key'
+        lines = data.sort.map { |option, value| "#{option} #{value}" }
+        lines << ''
+        lines.join "\n"
+      elsif params['format'] == 'arrays_with_sortkey'
+        lines = data.sort.map { |sortkey, pair| "#{pair[0]} #{pair[1]}" }
+        lines << ''
+        lines.join "\n"
+      else
         raise "unknown table content format \"#{params['format']}\""
       end
-      lines = data.sort.map { |option, value| "#{option} #{value}" }
-      lines << ''
-      lines.join "\n"
     end
 
     def generate_resources(recipe)


### PR DESCRIPTION
Now you may specify order-sensitive tables like the cidr, regexp or pcre types with the arrays_with_sortkey format that allows explizit ordering independent of user data.
